### PR TITLE
Major refactoring

### DIFF
--- a/graph/copy.go
+++ b/graph/copy.go
@@ -16,7 +16,6 @@ func NodeDeepCopy(n *Node) *Node {
 		label: n.label,
 		attrs: maps.Clone(n.attrs),
 		graph: n.graph,
-		style: n.style,
 	}
 }
 
@@ -29,7 +28,6 @@ func EdgeDeepCopy(e *Edge) *Edge {
 		to:     NodeDeepCopy(e.To().(*Node)),
 		weight: e.weight,
 		attrs:  maps.Clone(e.attrs),
-		style:  e.style,
 	}
 }
 

--- a/graph/copy_test.go
+++ b/graph/copy_test.go
@@ -3,11 +3,13 @@ package graph
 import (
 	"reflect"
 	"testing"
+
+	"github.com/milosgajdos/go-hypher"
 )
 
 func TestCopy(t *testing.T) {
 	t.Run("EmptyGraph", func(t *testing.T) {
-		g, err := NewGraph(WithLabel("foo"))
+		g, err := NewGraph(hypher.WithLabel("foo"))
 		if err != nil {
 			t.Fatalf("failed to create graph: %v", err)
 		}

--- a/graph/edge_test.go
+++ b/graph/edge_test.go
@@ -3,10 +3,12 @@ package graph
 import (
 	"reflect"
 	"testing"
+
+	"github.com/milosgajdos/go-hypher"
 )
 
 // MustEdge creates a new Edge and returns it, panicking if there's an error.
-func MustEdge(t *testing.T, from, to *Node, opts ...Option) *Edge {
+func MustEdge(t *testing.T, from, to *Node, opts ...hypher.Option) *Edge {
 	e, err := NewEdge(from, to, opts...)
 	if err != nil {
 		t.Fatalf("failed to create new edge: %v", err)
@@ -16,8 +18,8 @@ func MustEdge(t *testing.T, from, to *Node, opts ...Option) *Edge {
 
 func TestNewEdge(t *testing.T) {
 	g := MustGraph(t)
-	n1 := MustNode(t, WithGraph(g))
-	n2 := MustNode(t, WithGraph(g))
+	n1 := MustNode(t, hypher.WithGraph(g))
+	n2 := MustNode(t, hypher.WithGraph(g))
 
 	e := MustEdge(t, n1, n2)
 
@@ -58,18 +60,6 @@ func TestNewEdge(t *testing.T) {
 	if l := e.Label(); l != newLabel {
 		t.Errorf("expected label: %s, got: %s", newLabel, l)
 	}
-
-	if s := e.Style(); s != DefaultEdgeStyleType {
-		t.Errorf("expected style: %s, got: %s", DefaultEdgeStyleType, s)
-	}
-
-	if s := e.Shape(); s != DefaultEdgeShape {
-		t.Errorf("expected shape: %s, got: %s", DefaultEdgeShape, s)
-	}
-
-	if c := e.Color(); c != DefaultEdgeColor {
-		t.Errorf("expected color: %v, got: %v", DefaultEdgeColor, c)
-	}
 }
 
 func TestNewEdgeWithOptions(t *testing.T) {
@@ -81,10 +71,13 @@ func TestNewEdgeWithOptions(t *testing.T) {
 	)
 	attrs := map[string]any{"foo": "bar"}
 
-	from := MustNode(t, WithGraph(g), WithAttrs(attrs))
-	to := MustNode(t, WithGraph(g), WithAttrs(attrs))
+	from := MustNode(t, hypher.WithGraph(g), hypher.WithAttrs(attrs))
+	to := MustNode(t, hypher.WithGraph(g), hypher.WithAttrs(attrs))
 
-	e, err := NewEdge(from, to, WithLabel(testLabel), WithAttrs(attrs), WithWeight(testWeight))
+	e, err := NewEdge(from, to,
+		hypher.WithLabel(testLabel),
+		hypher.WithAttrs(attrs),
+		hypher.WithWeight(testWeight))
 	if err != nil {
 		t.Fatalf("failed to create new edge: %v", err)
 	}
@@ -111,8 +104,8 @@ func TestNewEdgeWithOptions(t *testing.T) {
 
 func TestEdgeReversed(t *testing.T) {
 	g := MustGraph(t)
-	n1 := MustNode(t, WithGraph(g))
-	n2 := MustNode(t, WithGraph(g))
+	n1 := MustNode(t, hypher.WithGraph(g))
+	n2 := MustNode(t, hypher.WithGraph(g))
 
 	e1 := MustEdge(t, n1, n2)
 	e2 := e1.ReversedEdge().(*Edge)

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -38,9 +38,9 @@ type Graph struct {
 }
 
 // NewGraph creates a new graph and returns it.
-func NewGraph(opts ...Option) (*Graph, error) {
+func NewGraph(opts ...hypher.Option) (*Graph, error) {
 	uid := uuid.New().String()
-	gopts := Options{
+	gopts := hypher.Options{
 		UID:    uid,
 		DotID:  uid,
 		Label:  DefaultGraphLabel,
@@ -129,18 +129,12 @@ func (g *Graph) Attributes() []encoding.Attribute {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
-	styleAttrs := []encoding.Attribute{
-		{Key: "label", Value: g.label},
-		{Key: "labelloc", Value: "t"},
-	}
-
 	a := AttrsToStringMap(g.attrs)
 	attributes := make([]encoding.Attribute, 0, len(a))
 
 	for k, v := range a {
 		attributes = append(attributes, encoding.Attribute{Key: k, Value: v})
 	}
-	attributes = append(attributes, styleAttrs...)
 
 	return attributes
 }
@@ -196,8 +190,8 @@ func (g *Graph) Outputs() []*Node {
 
 // NewNode creates a new node and adds it to the graph.
 // It returns the new node or fails with error.
-func (g *Graph) NewNode(opts ...Option) (*Node, error) {
-	opts = append(opts, WithGraph(g))
+func (g *Graph) NewNode(opts ...hypher.Option) (*Node, error) {
+	opts = append(opts, hypher.WithGraph(g))
 	return NewNode(opts...)
 }
 
@@ -247,8 +241,8 @@ func (g *Graph) AddNode(n *Node) error {
 
 // NewEdge creates a new edge link its node in the graph.
 // It returns the new edge or fails with error.
-func (g *Graph) NewEdge(from, to hypher.Node, opts ...Option) (*Edge, error) {
-	opts = append(opts, WithGraph(g))
+func (g *Graph) NewEdge(from, to hypher.Node, opts ...hypher.Option) (*Edge, error) {
+	opts = append(opts, hypher.WithGraph(g))
 	return NewEdge(from, to, opts...)
 }
 
@@ -566,9 +560,9 @@ func (g *Graph) run(ctx context.Context) error {
 // Run is a blocking call. It returns when
 // when the graph execution finished or if any
 // of the executed nodes Op failed with error.
-func (g *Graph) Run(ctx context.Context, inputs map[string]hypher.Value, opts ...Option) error {
+func (g *Graph) Run(ctx context.Context, inputs map[string]hypher.Value, opts ...hypher.Option) error {
 	// NOTE: we only read Parallel option.
-	gopts := Options{}
+	gopts := hypher.Options{}
 	for _, apply := range opts {
 		apply(&gopts)
 	}
@@ -582,7 +576,7 @@ func (g *Graph) Run(ctx context.Context, inputs map[string]hypher.Value, opts ..
 		}
 	}
 
-	if gopts.RunAll {
+	if gopts.RunMode == hypher.RunAllMode {
 		return g.runAll(ctx)
 	}
 

--- a/graph/marshal/dot/dot.go
+++ b/graph/marshal/dot/dot.go
@@ -2,27 +2,74 @@ package dot
 
 import (
 	"github.com/milosgajdos/go-hypher"
+	"github.com/milosgajdos/go-hypher/graph"
 
 	"gonum.org/v1/gonum/graph/encoding/dot"
 )
 
 // Marshaler is used for marshaling graph to DOT format.
 type Marshaler struct {
-	name   string
-	prefix string
-	indent string
+	name       string
+	prefix     string
+	indent     string
+	nodeStyle  Style
+	edgeStyle  Style
+	graphStyle Style
 }
 
 // NewMarshaler creates a new DOT graph marshaler and returns it.
-func NewMarshaler(name, prefix, indent string) (*Marshaler, error) {
+func NewMarshaler(name, prefix, indent string, opts ...Option) (*Marshaler, error) {
+	dotOpts := Options{
+		NodeStyle:  DefaultNodeStyle(),
+		EdgeStyle:  DefaultEdgeStyle(),
+		GraphStyle: DefaultGraphStyle(),
+	}
+
+	for _, apply := range opts {
+		apply(&dotOpts)
+	}
+
 	return &Marshaler{
-		name:   name,
-		prefix: prefix,
-		indent: indent,
+		name:       name,
+		prefix:     prefix,
+		indent:     indent,
+		nodeStyle:  dotOpts.NodeStyle,
+		edgeStyle:  dotOpts.EdgeStyle,
+		graphStyle: dotOpts.GraphStyle,
 	}, nil
 }
 
 // Marshal marshal g into DOT and returns it.
 func (m *Marshaler) Marshal(g hypher.Graph) ([]byte, error) {
+	// Apply DOT styling
+
+	hg := g.(*graph.Graph)
+	hg.Attrs()["label"] = hg.Label()
+	for k, v := range m.graphStyle.Attrs {
+		hg.Attrs()[k] = v
+	}
+
+	nodes := g.Nodes()
+	for nodes.Next() {
+		n := nodes.Node().(*graph.Node)
+		n.Attrs()["label"] = n.Label()
+		n.Attrs()["shape"] = m.nodeStyle.Shape
+		n.Attrs()["style"] = m.nodeStyle.Type
+		for k, v := range m.nodeStyle.Attrs {
+			n.Attrs()[k] = v
+		}
+	}
+
+	edges := g.Edges()
+	for edges.Next() {
+		e := edges.Edge().(*graph.Edge)
+		e.Attrs()["label"] = e.Label()
+		e.Attrs()["shape"] = m.edgeStyle.Shape
+		e.Attrs()["style"] = m.edgeStyle.Type
+		for k, v := range m.edgeStyle.Attrs {
+			e.Attrs()[k] = v
+		}
+	}
+
 	return dot.Marshal(g, m.name, m.prefix, m.indent)
 }

--- a/graph/marshal/dot/options.go
+++ b/graph/marshal/dot/options.go
@@ -1,0 +1,35 @@
+package dot
+
+// Options configure graph.
+type Options struct {
+	// NodeStyle configures Node style.
+	NodeStyle Style
+	// EdgeStyle configures Edge style.
+	EdgeStyle Style
+	// GraphStyle configures Graphe style.
+	GraphStyle Style
+}
+
+// Option is functional graph option.
+type Option func(*Options)
+
+// WithNodeStyle sets Node Style.
+func WithNodeStyle(s Style) Option {
+	return func(o *Options) {
+		o.NodeStyle = s
+	}
+}
+
+// WithEdgeStyle sets Edge Style.
+func WithEdgeStyle(s Style) Option {
+	return func(o *Options) {
+		o.EdgeStyle = s
+	}
+}
+
+// WithGraphStyle sets Gra[h style.
+func WithGraphStyle(s Style) Option {
+	return func(o *Options) {
+		o.GraphStyle = s
+	}
+}

--- a/graph/marshal/dot/style.go
+++ b/graph/marshal/dot/style.go
@@ -1,4 +1,4 @@
-package graph
+package dot
 
 import (
 	"image/color"
@@ -32,6 +32,8 @@ type Style struct {
 	Shape string
 	// Color is style color.
 	Color color.RGBA
+	// Attrs are style attributes
+	Attrs map[string]any
 }
 
 // DefaultNodeStyle returns default node style
@@ -40,6 +42,7 @@ func DefaultNodeStyle() Style {
 		Type:  DefaultNodeStyleType,
 		Shape: DefaultNodeShape,
 		Color: DefaultNodeColor,
+		Attrs: make(map[string]any),
 	}
 }
 
@@ -49,5 +52,15 @@ func DefaultEdgeStyle() Style {
 		Type:  DefaultEdgeStyleType,
 		Shape: DefaultEdgeShape,
 		Color: DefaultEdgeColor,
+		Attrs: make(map[string]any),
+	}
+}
+
+// DefaultGraphStyle returns default graph style.
+func DefaultGraphStyle() Style {
+	return Style{
+		Attrs: map[string]any{
+			"labelloc": "t",
+		},
 	}
 }

--- a/graph/marshal/dot/style_test.go
+++ b/graph/marshal/dot/style_test.go
@@ -1,17 +1,18 @@
-package graph
+package dot
 
 import (
 	"reflect"
 	"testing"
 )
 
-func TestDefaultNode(t *testing.T) {
+func TestDefaultNodeStyle(t *testing.T) {
 	dn := DefaultNodeStyle()
 
 	s := Style{
 		Type:  DefaultNodeStyleType,
 		Shape: DefaultNodeShape,
 		Color: DefaultNodeColor,
+		Attrs: make(map[string]any),
 	}
 
 	if !reflect.DeepEqual(dn, s) {
@@ -19,16 +20,31 @@ func TestDefaultNode(t *testing.T) {
 	}
 }
 
-func TestDefaultEdge(t *testing.T) {
+func TestDefaultEdgeStyle(t *testing.T) {
 	de := DefaultEdgeStyle()
 
 	s := Style{
 		Type:  DefaultEdgeStyleType,
 		Shape: DefaultEdgeShape,
 		Color: DefaultEdgeColor,
+		Attrs: make(map[string]any),
 	}
 
 	if !reflect.DeepEqual(de, s) {
 		t.Fatal("unexpected default edge style")
+	}
+}
+
+func TestDefaultGraphStyle(t *testing.T) {
+	dg := DefaultGraphStyle()
+
+	s := Style{
+		Attrs: map[string]any{
+			"labelloc": "t",
+		},
+	}
+
+	if !reflect.DeepEqual(dg, s) {
+		t.Fatal("unexpected default graph style")
 	}
 }

--- a/graph/node_test.go
+++ b/graph/node_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/milosgajdos/go-hypher"
 )
 
-func MustNode(t *testing.T, opts ...Option) *Node {
+func MustNode(t *testing.T, opts ...hypher.Option) *Node {
 	n, err := NewNode(opts...)
 	if err != nil {
 		t.Fatalf("failed to create new node: %v", err)
@@ -38,18 +38,6 @@ func TestNewNode(t *testing.T) {
 
 	if n.Graph() != nil {
 		t.Error("expected nil graph")
-	}
-
-	if s := n.Type(); s != DefaultNodeStyleType {
-		t.Errorf("expected type: %s, got: %s", DefaultNodeStyleType, s)
-	}
-
-	if s := n.Shape(); s != DefaultNodeShape {
-		t.Errorf("expected shape: %s, got: %s", DefaultNodeShape, s)
-	}
-
-	if c := n.Color(); c != DefaultNodeColor {
-		t.Errorf("expected color: %v, got: %v", DefaultNodeColor, c)
 	}
 
 	if d := n.DOTID(); d != n.UID() {
@@ -98,36 +86,17 @@ func TestNewNodeWithOptions(t *testing.T) {
 		"foo": "bar",
 	}
 
-	style := Style{
-		Type:  "foo",
-		Shape: "bar",
-		Color: DefaultNodeColor,
-	}
-
-	opts := []Option{
-		WithID(testID),
-		WithLabel(testLabel),
-		WithAttrs(attrs),
-		WithUID(testUID),
-		WithDotID(testDotID),
-		WithStyle(style),
+	opts := []hypher.Option{
+		hypher.WithID(testID),
+		hypher.WithLabel(testLabel),
+		hypher.WithAttrs(attrs),
+		hypher.WithUID(testUID),
+		hypher.WithDotID(testDotID),
 	}
 
 	n, err := NewNode(opts...)
 	if err != nil {
 		t.Fatalf("failed to create new node: %v", err)
-	}
-
-	if s := n.Type(); s != style.Type {
-		t.Errorf("expected style: %s, got: %s", style.Type, s)
-	}
-
-	if s := n.Shape(); s != style.Shape {
-		t.Errorf("expected shape: %s, got: %s", style.Shape, s)
-	}
-
-	if c := n.Color(); c != style.Color {
-		t.Errorf("expected color: %v, got: %v", style.Color, c)
 	}
 
 	if id := n.ID(); id != testID {
@@ -145,7 +114,7 @@ func TestNewNodeWithOptions(t *testing.T) {
 
 func TestNodeWithGraph(t *testing.T) {
 	g := MustGraph(t)
-	n := MustNode(t, WithGraph(g))
+	n := MustNode(t, hypher.WithGraph(g))
 
 	if n.ID() == NoneID {
 		t.Error("expected non-NoneID")
@@ -157,7 +126,9 @@ func TestNodeWithGraph(t *testing.T) {
 }
 
 func TestNodeClone(t *testing.T) {
-	n1 := MustNode(t, WithLabel("TestNode"), WithAttrs(map[string]any{"key": "value"}))
+	n1 := MustNode(t,
+		hypher.WithLabel("TestNode"),
+		hypher.WithAttrs(map[string]any{"key": "value"}))
 	n2, err := n1.Clone()
 	if err != nil {
 		t.Fatalf("failed to clone node: %v", err)
@@ -182,7 +153,7 @@ func TestNodeClone(t *testing.T) {
 
 func TestNodeCloneTo(t *testing.T) {
 	g1 := MustGraph(t)
-	n1 := MustNode(t, WithGraph(g1))
+	n1 := MustNode(t, hypher.WithGraph(g1))
 
 	g2 := MustGraph(t)
 	n2, err := n1.CloneTo(g2)

--- a/graph/op.go
+++ b/graph/op.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/milosgajdos/go-hypher"
 )
@@ -9,8 +10,9 @@ import (
 // NoOp is a no-op Op.
 type NoOp struct{}
 
-func (op NoOp) Type() string { return "NoOp" }
-func (op NoOp) Desc() string { return "NoOp does nothing" }
+func (op NoOp) Type() string   { return "NoOp" }
+func (op NoOp) Desc() string   { return "NoOp does nothing" }
+func (op NoOp) String() string { return fmt.Sprintf("Op: %s, Desc: %s", op.Type(), op.Desc()) }
 
 func (op NoOp) Do(_ context.Context, _ ...hypher.Value) (hypher.Value, error) {
 	return hypher.Value{}, nil

--- a/graph/sqlite/loader.go
+++ b/graph/sqlite/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/milosgajdos/go-hypher"
 	"github.com/milosgajdos/go-hypher/graph"
 )
 
@@ -57,9 +58,9 @@ func (l *Loader) Load(ctx context.Context, uid string) (*graph.Graph, error) {
 
 	// Create the in-memory graph
 	g, err := graph.NewGraph(
-		graph.WithUID(uid),
-		graph.WithLabel(label),
-		graph.WithAttrs(attrs),
+		hypher.WithUID(uid),
+		hypher.WithLabel(label),
+		hypher.WithAttrs(attrs),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create in-memory graph: %w", err)
@@ -105,10 +106,10 @@ func (l *Loader) Load(ctx context.Context, uid string) (*graph.Graph, error) {
 
 		// Create node and add it to the graph
 		node, err := graph.NewNode(
-			graph.WithID(id),
-			graph.WithUID(nodeUID),
-			graph.WithLabel(nodeLabel),
-			graph.WithAttrs(nodeAttrs),
+			hypher.WithID(id),
+			hypher.WithUID(nodeUID),
+			hypher.WithLabel(nodeLabel),
+			hypher.WithAttrs(nodeAttrs),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create node: %w", err)
@@ -171,10 +172,10 @@ func (l *Loader) Load(ctx context.Context, uid string) (*graph.Graph, error) {
 		}
 
 		edge, err := graph.NewEdge(sourceNode, targetNode,
-			graph.WithUID(edgeUID),
-			graph.WithLabel(edgeLabel),
-			graph.WithWeight(weight),
-			graph.WithAttrs(edgeAttrs),
+			hypher.WithUID(edgeUID),
+			hypher.WithLabel(edgeLabel),
+			hypher.WithWeight(weight),
+			hypher.WithAttrs(edgeAttrs),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create edge: %w", err)

--- a/graph/sqlite/loader_test.go
+++ b/graph/sqlite/loader_test.go
@@ -31,11 +31,11 @@ func TestLoader_Load(t *testing.T) {
 	}
 
 	// Create two nodes
-	nodeOpts := []graph.Option{
-		graph.WithID(1),
-		graph.WithUID("node1"),
-		graph.WithLabel("Node 1"),
-		graph.WithAttrs(map[string]any{"key": "value"}),
+	nodeOpts := []hypher.Option{
+		hypher.WithID(1),
+		hypher.WithUID("node1"),
+		hypher.WithLabel("Node 1"),
+		hypher.WithAttrs(map[string]any{"key": "value"}),
 	}
 
 	node1, err := graph.NewNode(nodeOpts...)
@@ -46,11 +46,11 @@ func TestLoader_Load(t *testing.T) {
 		t.Fatalf("failed to add node: %d: %v", node1.ID(), err)
 	}
 
-	nodeOpts = []graph.Option{
-		graph.WithID(2),
-		graph.WithUID("node2"),
-		graph.WithLabel("Node 2"),
-		graph.WithAttrs(map[string]any{"key": "value"}),
+	nodeOpts = []hypher.Option{
+		hypher.WithID(2),
+		hypher.WithUID("node2"),
+		hypher.WithLabel("Node 2"),
+		hypher.WithAttrs(map[string]any{"key": "value"}),
 	}
 
 	node2, err := graph.NewNode(nodeOpts...)
@@ -62,11 +62,11 @@ func TestLoader_Load(t *testing.T) {
 	}
 
 	// Create an edge between the two nodes
-	edgeOpts := []graph.Option{
-		graph.WithUID("edge1"),
-		graph.WithLabel("Edge 1"),
-		graph.WithWeight(1.0),
-		graph.WithAttrs(map[string]any{"key2": "value2"}),
+	edgeOpts := []hypher.Option{
+		hypher.WithUID("edge1"),
+		hypher.WithLabel("Edge 1"),
+		hypher.WithWeight(1.0),
+		hypher.WithAttrs(map[string]any{"key2": "value2"}),
 	}
 
 	edge, err := graph.NewEdge(node1, node2, edgeOpts...)

--- a/graph/sqlite/syncer_test.go
+++ b/graph/sqlite/syncer_test.go
@@ -30,11 +30,11 @@ func TestSyncer_Sync(t *testing.T) {
 		t.Fatalf("failed to create new graph: %v", err)
 	}
 
-	nodeOpts := []graph.Option{
-		graph.WithID(1),
-		graph.WithUID("node1"),
-		graph.WithLabel("Node 1"),
-		graph.WithAttrs(map[string]interface{}{"key": "value"}),
+	nodeOpts := []hypher.Option{
+		hypher.WithID(1),
+		hypher.WithUID("node1"),
+		hypher.WithLabel("Node 1"),
+		hypher.WithAttrs(map[string]interface{}{"key": "value"}),
 	}
 
 	node1, err := graph.NewNode(nodeOpts...)
@@ -42,11 +42,11 @@ func TestSyncer_Sync(t *testing.T) {
 		t.Fatalf("failed to create new node: %v", err)
 	}
 
-	nodeOpts = []graph.Option{
-		graph.WithID(2),
-		graph.WithUID("node2"),
-		graph.WithLabel("Node 2"),
-		graph.WithAttrs(map[string]interface{}{"key": "value"}),
+	nodeOpts = []hypher.Option{
+		hypher.WithID(2),
+		hypher.WithUID("node2"),
+		hypher.WithLabel("Node 2"),
+		hypher.WithAttrs(map[string]interface{}{"key": "value"}),
 	}
 
 	node2, err := graph.NewNode(nodeOpts...)
@@ -54,11 +54,11 @@ func TestSyncer_Sync(t *testing.T) {
 		t.Fatalf("failed to create new node: %v", err)
 	}
 
-	edgeOpts := []graph.Option{
-		graph.WithUID("edge1"),
-		graph.WithLabel("Edge 1"),
-		graph.WithWeight(1.0),
-		graph.WithAttrs(map[string]interface{}{"key2": "value2"}),
+	edgeOpts := []hypher.Option{
+		hypher.WithUID("edge1"),
+		hypher.WithLabel("Edge 1"),
+		hypher.WithWeight(1.0),
+		hypher.WithAttrs(map[string]interface{}{"key2": "value2"}),
 	}
 
 	edge, err := graph.NewEdge(node1, node2, edgeOpts...)

--- a/hypher.go
+++ b/hypher.go
@@ -2,7 +2,13 @@
 //
 // An agent is represented as a weighted Directed Acyclic Graph (DAG)
 // which consists of nodes that perform a specific operation during
-// agent execution.
+// agent execution aka Hypher Run.
+//
+// Hypher Run executes all the nodes in the hypher Graph and computes
+// the results of their operations. All the outputs of the nodes
+// are then passed to theis successors which then use them as their inputs.
+// This continues all the way down to the hypher graph output nodes where
+// the agent result is stored and can be fetched from.
 //
 // Given the agents are DAGs, they can form ensambles of agents
 // through additional edges that link the agent DAGs as long
@@ -11,7 +17,6 @@ package hypher
 
 import (
 	"context"
-	"image/color"
 
 	"gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/encoding"
@@ -28,6 +33,8 @@ type Graph interface {
 	Label() string
 	// Attrs are graph attributes.
 	Attrs() map[string]any
+	// String is useful for debugging.
+	String() string
 }
 
 // DOTNGraph is Graphviz DOT graph.
@@ -51,18 +58,12 @@ type Node interface {
 	Label() string
 	// Attrs returns node attributes.
 	Attrs() map[string]any
+	// String is useful for debugging.
+	String() string
 }
 
-// Styler is used for styling.
-type Styler interface {
-	// Type returns the type of style.
-	// TODO: rename to Style
-	Type() string
-	// Shape returns style shape.
-	Shape() string
-	// Color returns style color.
-	Color() color.RGBA
-}
+// Nodes is a slice of Nodes.
+type Nodes []Node
 
 // DOTNode is Graphviz DOT node.
 type DOTNode interface {
@@ -83,6 +84,8 @@ type Edge interface {
 	Label() string
 	// Attrs returns node attributes.
 	Attrs() map[string]any
+	// String is useful for debugging.
+	String() string
 }
 
 // LabelSetter sets label.
@@ -165,6 +168,20 @@ type Loader interface {
 // Value is an I/O value.
 type Value map[string]any
 
+// Runner is used to trigger a hypher Run.
+// This usually means running the hypher Graph, by executing all its nodes.
+type Runner interface {
+	// Run an operation with the given inputs and options.
+	Run(ctx context.Context, inputs map[string]Value, opts ...Option) error
+}
+
+// Execer executes a hypher operation.
+// This usually means executing the hypher Node, by running its Op.
+type Execer interface {
+	// Exec executes an operation with the given inputs and returns the results.
+	Exec(ctx context.Context, inputs ...Value) (Value, error)
+}
+
 // Op is an operation run by a Node.
 type Op interface {
 	// Type of the Op.
@@ -172,5 +189,7 @@ type Op interface {
 	// Desc describes the Op.
 	Desc() string
 	// Do runs the Op.
-	Do(context.Context, ...Value) (Value, error)
+	Do(ctx context.Context, inputs ...Value) (Value, error)
+	// String is useful for debugging.
+	String() string
 }

--- a/options.go
+++ b/options.go
@@ -1,9 +1,15 @@
-package graph
+package hypher
 
-import (
-	"maps"
+import "maps"
 
-	"github.com/milosgajdos/go-hypher"
+// RunMode is Graph run mode.
+type RunMode int
+
+const (
+	// RunLevelMode runs node on the same graph level concurrently
+	RunLevelMode RunMode = iota
+	// RunAllMode runs all Graph nodes concurrently.
+	RunAllMode
 )
 
 // Options configure graph.
@@ -15,19 +21,17 @@ type Options struct {
 	// Label configures Label.
 	Label string
 	// Attrs configures Attrs.
-	Attrs map[string]interface{}
+	Attrs map[string]any
 	// DotID configures DOT ID
 	DotID string
-	// Weight configures weight.
+	// Weight configures Edge weight.
 	Weight float64
-	// Graph configures node's graph
-	Graph *Graph
-	// Op configures node's Op.
-	Op hypher.Op
-	// Style configures style.
-	Style Style
-	// RunAll configures run.
-	RunAll bool
+	// Graph configures Node's graph
+	Graph Graph
+	// RunMode configures Graph run mode.
+	RunMode RunMode
+	// Op configures Node's Op.
+	Op Op
 }
 
 // Option is functional graph option.
@@ -55,7 +59,7 @@ func WithLabel(label string) Option {
 }
 
 // WithAttrs sets Attrs option,
-func WithAttrs(attrs map[string]interface{}) Option {
+func WithAttrs(attrs map[string]any) Option {
 	return func(o *Options) {
 		o.Attrs = maps.Clone(attrs)
 	}
@@ -75,30 +79,23 @@ func WithWeight(weight float64) Option {
 	}
 }
 
-// WithGraph sets Graph options.
-func WithGraph(g *Graph) Option {
+// WithGraph sets hypher Graph.
+func WithGraph(g Graph) Option {
 	return func(o *Options) {
 		o.Graph = g
 	}
 }
 
+// WithRunAll sets Parallel option.
+func WithRunMode(mode RunMode) Option {
+	return func(o *Options) {
+		o.RunMode = mode
+	}
+}
+
 // WithOp sets Op.
-func WithOp(op hypher.Op) Option {
+func WithOp(op Op) Option {
 	return func(o *Options) {
 		o.Op = op
-	}
-}
-
-// WithStyle sets Style option.
-func WithStyle(s Style) Option {
-	return func(o *Options) {
-		o.Style = s
-	}
-}
-
-// WithRunAll sets Parallel option.
-func WithRunAll() Option {
-	return func(o *Options) {
-		o.RunAll = true
 	}
 }


### PR DESCRIPTION
* moved Options to the core `hypher` module package
* `Style` is now applied only during marshalling (there is no need to pay the mem footprint penalty)
* introduced `RunMode` type for different `Graph` run modes
* introduced `Runner` and `Execer` interfaces.